### PR TITLE
Properly handle interrupt signals

### DIFF
--- a/src/awssh/_version.py
+++ b/src/awssh/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this module."""
-__version__ = "1.0.0"
+__version__ = "1.0.1"


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

This PR fixes an issue with signal handling within interactive shells of child processes.  Specifically, 
pressing `control-c` in a shell causes `awssh` to exit instead of allowing the shell to interpret the signal.  

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

Currently, `control-c` will exit `awssh` which ends a user's remote session.
This is broken and infuriating.   By setting an ignore action on the interrupt signal, in the parent, 
before the`subprocess` call, the child can then handle the signal as expected.
The signal's action in the parent is restored after the child exits for good measure.

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Tested on my local machine by connecting to various AWS instances and furiously mashing `control-c`.
Tested with standard suite of continuous integration actions.

![monday-typing-monkey](https://user-images.githubusercontent.com/3229435/184724467-d4c62065-1f2f-4927-974c-0fa4cb47810c.gif)


## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [x] Add a tag or create a release.
