### PR TITLE
Add nix flake

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,3 +8,7 @@
 # These folks own any files in the .github directory at the root of
 # the repository and any of its subdirectories.
 /.github/ @dav3r @felddy @jasonodoom @jsf9k @mcdonnnj
+
+# Our Nix and flake expert(s) own these files.
+*.nix @jasonodoom
+flake.* @jasonodoom

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ __pycache__
 .python-version
 *.egg-info
 dist
+result

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 # Files already tracked by Git are not affected.
 # See: https://git-scm.com/docs/gitignore
 
+## Nix ##
+result
+
 ## Python ##
 __pycache__
 .coverage
@@ -10,4 +13,3 @@ __pycache__
 .python-version
 *.egg-info
 dist
-result

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This project provides a tool that simplifies secure shell connections over
 ## Nix ###
 
 If you have [Nix](https://nixos.org/download.html) installed you can use
-the [flake.nix](flake.nix) configuration file located at the root of the
+the [`flake.nix`](flake.nix) configuration file located at the root of the
 project to build and run `awssh`:
 
 ```console

--- a/README.md
+++ b/README.md
@@ -89,6 +89,13 @@ your `awssh` command:
   when you tab complete, the name will be transformed into the instance ID
   (assuming you have typed enough of the name to identify a unique instance).
 
+## Special development pre-requisites ##
+
+> [!Note]
+> This project supports installation via a [Nix](https://nixos.org/)
+> [`flake.nix`](https://nixos.wiki/wiki/Flakes) file, and as a result
+> the `bump_version.sh` script requires that Nix be installed locally.
+
 ## Contributing ##
 
 We welcome contributions!  Please see [`CONTRIBUTING.md`](CONTRIBUTING.md) for

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ After the build has completed, the `awssh` executable can be found at:
 To run the program simply execute the binary from the project root:
 
 ```console
-result/bin/awssh -h
+result/bin/awssh --help
 ```
 
 ### Start a SSM shell session without ssh ###

--- a/README.md
+++ b/README.md
@@ -53,9 +53,8 @@ project to build and run `awssh`:
 nix build
 ```
 
-After the build has completed the program will a `result` directory will
-appear within the root of the project. This directory contains a `bin`
-subdirectory where the executable `awssh` can be found: `result/bin/awssh`
+After the build has completed, the `awssh` executable can be found at:
+`result/bin/awssh`
 
 To run the program simply execute the binary from the project root:
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ This project provides a tool that simplifies secure shell connections over
 
 If you have [Nix](https://nixos.org/download.html) installed you can use
 the [flake.nix](flake.nix) configuration file located at the root of the
-project to build and run the `awssh`:
+project to build and run `awssh`:
 
 ```console
 nix build

--- a/README.md
+++ b/README.md
@@ -91,17 +91,17 @@ your `awssh` command:
   when you tab complete, the name will be transformed into the instance ID
   (assuming you have typed enough of the name to identify a unique instance).
 
-## Special development pre-requisites ##
+## Contributing ##
+
+We welcome contributions!  Please see [`CONTRIBUTING.md`](CONTRIBUTING.md) for
+details.
+
+### Special development pre-requisites ###
 
 > [!Note]
 > This project supports installation via a [Nix](https://nixos.org/)
 > [`flake.nix`](https://nixos.wiki/wiki/Flakes) file, and as a result
 > the `bump_version.sh` script requires that Nix be installed locally.
-
-## Contributing ##
-
-We welcome contributions!  Please see [`CONTRIBUTING.md`](CONTRIBUTING.md) for
-details.
 
 ## License ##
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,26 @@ This project provides a tool that simplifies secure shell connections over
    tab completion that will make life a lot easier for you.  Don't say we
    didn't warn you.
 
+## Nix ###
+
+If you have [Nix](https://nixos.org/download.html) installed you can use
+the [flake.nix](flake.nix) configuration file located at the root of the
+project to build and run the `awssh`:
+
+```console
+nix build
+```
+
+After the build has completed the program will a `result` directory will
+appear within the root of the project. This directory contains a `bin`
+subdirectory where the executable `awssh` can be found: `result/bin/awssh`
+
+To run the program simply execute the binary from the project root:
+
+```console
+result/bin/awssh -h
+```
+
 ### Start a SSM shell session without ssh ###
 
 ```console

--- a/bump_version.sh
+++ b/bump_version.sh
@@ -31,7 +31,7 @@ else
       sed "s/$old_version_regex/$new_version/" $VERSION_FILE > $tmp_file
       mv $tmp_file $VERSION_FILE
       sed "s/$old_version_regex/$new_version/" $FLAKE_FILE > $tmp_flake
-      mv $tmp_file $FLAKE_FILE
+      mv $tmp_flake $FLAKE_FILE
       # Run flake update to update the flake.lock file
       nix flake update
       git add $FLAKE_FILE $FLAKE_LOCK_FILE $VERSION_FILE

--- a/bump_version.sh
+++ b/bump_version.sh
@@ -2,6 +2,8 @@
 
 # bump_version.sh (show|major|minor|patch|prerelease|build)
 
+# The nix commands used in this file require the installation of Nix: https://nixos.org
+
 set -o nounset
 set -o errexit
 set -o pipefail

--- a/bump_version.sh
+++ b/bump_version.sh
@@ -28,6 +28,7 @@ else
       # as a result of macOS using the BSD version of sed
       tmp_file=/tmp/version.$$
       sed "s/$old_version_regex/$new_version/" $VERSION_FILE > $tmp_file
+      mv $tmp_file $VERSION_FILE
       sed "s/$old_version_regex/$new_version/" > $FLAKE_FILE
       # Run flake update to update the flake.lock file
       nix flake update

--- a/bump_version.sh
+++ b/bump_version.sh
@@ -34,8 +34,7 @@ else
       mv $tmp_file $FLAKE_FILE
       # Run flake update to update the flake.lock file
       nix flake update
-      git add $FLAKE_FILE $FLAKE_LOCK_FILE
-      git add $VERSION_FILE
+      git add $FLAKE_FILE $FLAKE_LOCK_FILE $VERSION_FILE
       git commit -m"Bump version from $old_version to $new_version"
       git push
       ;;

--- a/bump_version.sh
+++ b/bump_version.sh
@@ -6,6 +6,8 @@ set -o nounset
 set -o errexit
 set -o pipefail
 
+FLAKE_FILE=flake.nix
+FLAKE_LOCK_FILE=flake.lock
 VERSION_FILE=src/awssh/_version.py
 
 HELP_INFORMATION="bump_version.sh (show|major|minor|patch|prerelease|build|finalize)"
@@ -26,7 +28,10 @@ else
       # as a result of macOS using the BSD version of sed
       tmp_file=/tmp/version.$$
       sed "s/$old_version_regex/$new_version/" $VERSION_FILE > $tmp_file
-      mv $tmp_file $VERSION_FILE
+      sed "s/$old_version_regex/$new_version/" $FLAKE_FILE
+      # Run flake update to update the flake.lock file
+      nix flake update
+      git add $FLAKE_FILE $FLAKE_LOCK_FILE
       git add $VERSION_FILE
       git commit -m"Bump version from $old_version to $new_version"
       git push

--- a/bump_version.sh
+++ b/bump_version.sh
@@ -51,7 +51,7 @@ else
       mv $tmp_file $VERSION_FILE
       sed "s/$old_version_regex/$new_version/" $FLAKE_FILE > $tmp_flake
       mv $tmp_flake $FLAKE_FILE
-      git add $FLAKE_FILE $FLAKE_LOCK_FILE $VERSION_FILE
+      git add $FLAKE_FILE $VERSION_FILE
       git commit -m"Finalize version from $old_version to $new_version"
       git push
       ;;

--- a/bump_version.sh
+++ b/bump_version.sh
@@ -46,9 +46,12 @@ else
       # A temp file is used to provide compatability with macOS development
       # as a result of macOS using the BSD version of sed
       tmp_file=/tmp/version.$$
+      tmp_flake=/tmp/flake.tmp
       sed "s/$old_version_regex/$new_version/" $VERSION_FILE > $tmp_file
       mv $tmp_file $VERSION_FILE
-      git add $VERSION_FILE
+      sed "s/$old_version_regex/$new_version/" $FLAKE_FILE > $tmp_flake
+      mv $tmp_flake $FLAKE_FILE
+      git add $FLAKE_FILE $FLAKE_LOCK_FILE $VERSION_FILE
       git commit -m"Finalize version from $old_version to $new_version"
       git push
       ;;

--- a/bump_version.sh
+++ b/bump_version.sh
@@ -28,7 +28,7 @@ else
       # as a result of macOS using the BSD version of sed
       tmp_file=/tmp/version.$$
       sed "s/$old_version_regex/$new_version/" $VERSION_FILE > $tmp_file
-      sed "s/$old_version_regex/$new_version/" $FLAKE_FILE
+      sed "s/$old_version_regex/$new_version/" > $FLAKE_FILE
       # Run flake update to update the flake.lock file
       nix flake update
       git add $FLAKE_FILE $FLAKE_LOCK_FILE

--- a/bump_version.sh
+++ b/bump_version.sh
@@ -27,9 +27,11 @@ else
       # A temp file is used to provide compatability with macOS development
       # as a result of macOS using the BSD version of sed
       tmp_file=/tmp/version.$$
+      tmp_flake=/tmp/flake.tmp
       sed "s/$old_version_regex/$new_version/" $VERSION_FILE > $tmp_file
       mv $tmp_file $VERSION_FILE
-      sed "s/$old_version_regex/$new_version/" > $FLAKE_FILE
+      sed "s/$old_version_regex/$new_version/" $FLAKE_FILE > $tmp_flake
+      mv $tmp_file $FLAKE_FILE
       # Run flake update to update the flake.lock file
       nix flake update
       git add $FLAKE_FILE $FLAKE_LOCK_FILE

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1692742407,
+        "narHash": "sha256-faLzZ2u3Wki8h9ykEfzQr19B464eyADP3Ux7A/vjKIY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a2eca347ae1e542af3f818274c38305c1e00604c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "utils": "utils"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1692799911,
+        "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "f9e7cf818399d17d347f847525c5a5a8032e4e44",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1692808169,
-        "narHash": "sha256-x9Opq06rIiwdwGeK2Ykj69dNc2IvUH1fY55Wm7atwrE=",
-        "owner": "NixOS",
+        "lastModified": 1692794066,
+        "narHash": "sha256-H0aG8r16dj0x/Wz6wQhQxc9V7AsObOiHPaKxQgH6Y08=",
+        "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9201b5ff357e781bf014d0330d18555695df7ba8",
+        "rev": "fc944919f743bb22379dddf18dcb72db6cff84aa",
         "type": "github"
       },
       "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
+        "owner": "nixos",
+        "ref": "nixos-23.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -1,43 +1,6 @@
 {
   "nodes": {
-    "nixpkgs": {
-      "locked": {
-        "lastModified": 1692742407,
-        "narHash": "sha256-faLzZ2u3Wki8h9ykEfzQr19B464eyADP3Ux7A/vjKIY=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "a2eca347ae1e542af3f818274c38305c1e00604c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "root": {
-      "inputs": {
-        "nixpkgs": "nixpkgs",
-        "utils": "utils"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "utils": {
+    "flake-utils": {
       "inputs": {
         "systems": "systems"
       },
@@ -52,6 +15,43 @@
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1692808169,
+        "narHash": "sha256-x9Opq06rIiwdwGeK2Ykj69dNc2IvUH1fY55Wm7atwrE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9201b5ff357e781bf014d0330d18555695df7ba8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -18,8 +18,8 @@
               boto3
               docopt
               schema
-              wheel
               setuptools
+              wheel
               ];
             src = (pkgs.fetchFromGitHub {
               owner = "cisagov";

--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,8 @@
             hash = "sha256-4b2VBFUQye4wTvuagPwEImLwkUO4Dk5hvOYW+eg8OGA=";
           };
         };
-      in {
+      in
+      {
         packages.default = pkgs.python310Packages.buildPythonPackage rec {
           name = "awssh";
           version = "1.1.0";

--- a/flake.nix
+++ b/flake.nix
@@ -3,13 +3,11 @@
 
     inputs = {
       nixpkgs.url = "github:NixOS/nixpkgs?ref=nixpkgs-unstable";
-      utils.url = "github:numtide/flake-utils";
+      flake-utils.url = "github:numtide/flake-utils";
     };
-    outputs = { self, nixpkgs, utils }: {
-      devShell = self.defaultPackage;
-      defaultPackage.x86_64-darwin =
-        with import nixpkgs { system = "x86_64-darwin"; };
-        let
+    outputs = { self, nixpkgs, flake-utils }:
+      flake-utils.lib.eachDefaultSystem (system:
+        let pkgs = nixpkgs.legacyPackages.${system};
           awssh = pkgs.python310Packages.buildPythonPackage rec {
             pname = "awssh";
             version = "1.1.0";
@@ -21,15 +19,15 @@
               setuptools
               wheel
             ];
-            src = (pkgs.fetchFromGitHub {
+            src = pkgs.fetchFromGitHub {
               owner = "cisagov";
               repo = "awssh";
               rev = "v1.1.0";
               sha256 = "sha256-4b2VBFUQye4wTvuagPwEImLwkUO4Dk5hvOYW+eg8OGA=";
-            });
-          };
-        in
-          pkgs.python310Packages.buildPythonPackage rec {
+             };
+            };
+          in {
+          packages.default = pkgs.python310Packages.buildPythonPackage rec {
             pname = "awssh";
             version = "1.1.0";
             src = ./.;
@@ -39,7 +37,7 @@
               schema
               setuptools
               wheel
-            ];
-          };
-    };
-  }
+        ];
+      };
+    });
+}

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
     "Tool to simplify secure shell connections over AWS Systems Manager (SSM).";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?ref=nixpkgs-unstable";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-23.05";
     flake-utils.url = "github:numtide/flake-utils";
   };
   outputs = { self, nixpkgs, flake-utils }:

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
       let
         pkgs = nixpkgs.legacyPackages.${system};
         awssh = pkgs.python310Packages.buildPythonPackage rec {
-          pname = "awssh";
+          name = "awssh";
           version = "1.1.0";
           doCheck = false;
           propagatedBuildInputs = with pkgs.python310Packages; [
@@ -24,13 +24,13 @@
           src = pkgs.fetchFromGitHub {
             owner = "cisagov";
             repo = "awssh";
-            rev = "v1.1.0";
-            sha256 = "sha256-4b2VBFUQye4wTvuagPwEImLwkUO4Dk5hvOYW+eg8OGA=";
+            rev = "v${version}";
+            hash = "sha256-4b2VBFUQye4wTvuagPwEImLwkUO4Dk5hvOYW+eg8OGA=";
           };
         };
       in {
         packages.default = pkgs.python310Packages.buildPythonPackage rec {
-          pname = "awssh";
+          name = "awssh";
           version = "1.1.0";
           src = ./.;
           propagatedBuildInputs = with pkgs.python310Packages; [

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,46 @@
+{
+    description = "Tool to simplify secure shell connections over AWS simple systems manager.";
+  
+    inputs = {
+      nixpkgs.url = "github:NixOS/nixpkgs?ref=nixpkgs-unstable";
+      utils.url = "github:numtide/flake-utils";
+    };
+    outputs = { self, nixpkgs, utils }: {
+      devShell = self.defaultPackage;
+      defaultPackage.x86_64-darwin =
+        with import nixpkgs { system = "x86_64-darwin"; };
+        let
+          awssh = pkgs.python310Packages.buildPythonPackage rec {
+            pname = "awssh";
+            version = "1.1.0";
+            doCheck = false;
+            propagatedBuildInputs = with pkgs.python310Packages; [
+              boto3
+              docopt
+              schema
+              wheel
+              setuptools
+              ];
+            src = (pkgs.fetchFromGitHub {
+              owner = "cisagov";
+              repo = "awssh";
+              rev = "v1.1.0";
+              sha256 = "sha256-4b2VBFUQye4wTvuagPwEImLwkUO4Dk5hvOYW+eg8OGA=";
+          });};
+        in
+          pkgs.python310Packages.buildPythonPackage rec {
+            pname = "awssh";
+            version = "1.1.0";
+            src = ./.;
+            propagatedBuildInputs = with pkgs.python310Packages; [
+              boto3
+              docopt
+              schema
+              wheel
+              setuptools
+            ];
+          };
+    };
+  }
+  
+

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
     description = "Tool to simplify secure shell connections over AWS simple systems manager.";
-  
+
     inputs = {
       nixpkgs.url = "github:NixOS/nixpkgs?ref=nixpkgs-unstable";
       utils.url = "github:numtide/flake-utils";
@@ -20,13 +20,14 @@
               schema
               setuptools
               wheel
-              ];
+            ];
             src = (pkgs.fetchFromGitHub {
               owner = "cisagov";
               repo = "awssh";
               rev = "v1.1.0";
               sha256 = "sha256-4b2VBFUQye4wTvuagPwEImLwkUO4Dk5hvOYW+eg8OGA=";
-          });};
+            });
+          };
         in
           pkgs.python310Packages.buildPythonPackage rec {
             pname = "awssh";
@@ -36,11 +37,9 @@
               boto3
               docopt
               schema
-              wheel
               setuptools
+              wheel
             ];
           };
     };
   }
-  
-

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-    description = "Tool to simplify secure shell connections over AWS simple systems manager.";
+    description = "Tool to simplify secure shell connections over AWS Systems Manager (SSM).";
 
     inputs = {
       nixpkgs.url = "github:NixOS/nixpkgs?ref=nixpkgs-unstable";

--- a/flake.nix
+++ b/flake.nix
@@ -1,43 +1,45 @@
 {
-    description = "Tool to simplify secure shell connections over AWS Systems Manager (SSM).";
+  description =
+    "Tool to simplify secure shell connections over AWS Systems Manager (SSM).";
 
-    inputs = {
-      nixpkgs.url = "github:NixOS/nixpkgs?ref=nixpkgs-unstable";
-      flake-utils.url = "github:numtide/flake-utils";
-    };
-    outputs = { self, nixpkgs, flake-utils }:
-      flake-utils.lib.eachDefaultSystem (system:
-        let pkgs = nixpkgs.legacyPackages.${system};
-          awssh = pkgs.python310Packages.buildPythonPackage rec {
-            pname = "awssh";
-            version = "1.1.0";
-            doCheck = false;
-            propagatedBuildInputs = with pkgs.python310Packages; [
-              boto3
-              docopt
-              schema
-              setuptools
-              wheel
-            ];
-            src = pkgs.fetchFromGitHub {
-              owner = "cisagov";
-              repo = "awssh";
-              rev = "v1.1.0";
-              sha256 = "sha256-4b2VBFUQye4wTvuagPwEImLwkUO4Dk5hvOYW+eg8OGA=";
-             };
-            };
-          in {
-          packages.default = pkgs.python310Packages.buildPythonPackage rec {
-            pname = "awssh";
-            version = "1.1.0";
-            src = ./.;
-            propagatedBuildInputs = with pkgs.python310Packages; [
-              boto3
-              docopt
-              schema
-              setuptools
-              wheel
-        ];
-      };
-    });
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs?ref=nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        awssh = pkgs.python310Packages.buildPythonPackage rec {
+          pname = "awssh";
+          version = "1.1.0";
+          doCheck = false;
+          propagatedBuildInputs = with pkgs.python310Packages; [
+            boto3
+            docopt
+            schema
+            setuptools
+            wheel
+          ];
+          src = pkgs.fetchFromGitHub {
+            owner = "cisagov";
+            repo = "awssh";
+            rev = "v1.1.0";
+            sha256 = "sha256-4b2VBFUQye4wTvuagPwEImLwkUO4Dk5hvOYW+eg8OGA=";
+          };
+        };
+      in {
+        packages.default = pkgs.python310Packages.buildPythonPackage rec {
+          pname = "awssh";
+          version = "1.1.0";
+          src = ./.;
+          propagatedBuildInputs = with pkgs.python310Packages; [
+            boto3
+            docopt
+            schema
+            setuptools
+            wheel
+          ];
+        };
+      });
 }


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR adds `flake.nix` to allow for the use of `awssh` without the following:

1) Requiring Python to be installed on the host system
2) Executing `setup-env` script to install `awssh`
3) Managing, starting  or maintaining virtual environments for Python

![image](https://github.com/cisagov/awssh/assets/6789916/1db409ed-723d-4495-a871-b52ccaad1690)

This does not require or use `poetry`


<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The motivation and purpose of this is to provide access to our tools quickly. Considering the recent re-provisioning of my machine I find it convenient to simply run. `nix build` so I can execute `awssh` without having to configure virtualenvs or making other system changes.  This is just the beginning. 
  
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

The  binary was executed and I was able to successfully start a session as well as execute different `awssh` options. I've included a screenshot. 
<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [X] This PR has an informative and human-readable title.
- [X] Changes are limited to a single goal - *eschew scope creep!*
- [X] All relevant type-of-change labels have been added.
- [X] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [X] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [X] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
