### PR TITLE
Remove outdated Python package pin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ setup(
         "boto3",
         "docopt",
         "schema",
-        "setuptools >= 24.2.0",
+        "setuptools",
     ],
     extras_require={
         # IMPORTANT: Keep type hinting-related dependencies of the dev section


### PR DESCRIPTION
## 🗣 Description ##

This pull request removes an outdated Python package pin.

## 💭 Motivation and context ##

The `setuptools` pin was enforcing a version newer than a version from 2016, which seems unnecessary since we are only supporting Python 3.9 and up.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.